### PR TITLE
Fixed typographical error, changed Britian to Britain in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install the jwall audit console for modsecurity on an Ubuntu 12.04 machine
 ###cidr_to_ipset.sh
 Converts a text file with a list of CIDR ip blocks in to a saved hashset.  
 
-Sample lists of CIDR blocks available for US, Great Britian, Spain, Italy, and France
+Sample lists of CIDR blocks available for US, Great Britain, Spain, Italy, and France
 
 ###install_ipset_rules.sh
 Performs the following:


### PR DESCRIPTION
ssstonebraker, I've corrected a typographical error in the documentation of the [braker-scripts](https://github.com/ssstonebraker/braker-scripts) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
